### PR TITLE
build: fix ci build caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,16 +23,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: bazelbuild/setup-bazelisk@v1
-      - name: Mount bazel action cache
+      - name: Mount bazel caches
         uses: actions/cache@v2
         with:
-          path: "~/.cache/bazel"
-          key: bazel
-      - name: Mount bazel repo cache
-        uses: actions/cache@v2
-        with:
-          path: "~/.cache/bazel-repo"
-          key: bazel-repo
+          path: |
+            "~/.cache/bazel"
+            "~/.cache/bazel-repo"
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel caches
+        uses: actions/cache@v2
+        with:
+          path: |
+            "~/.cache/bazel"
+            "~/.cache/bazel-repo"
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here


### PR DESCRIPTION
@thesayyn 

Github actions caches don't update already existing caches, so the cache that gets loaded could be old. This sets a new cache using a cache key derived from a hash of files. The use of restore-keys: bazel-cache- will find the most recent cache stored scoped to this branch or a parent branch.