### PR TITLE
fix: move cache flags out of ci bazelrc

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -6,8 +6,5 @@ build --announce_rc
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors
-# This directory is configured in GitHub actions to be persisted between runs.
-build --disk_cache=$HOME/.cache/bazel
-build --repository_cache=$HOME/.cache/bazel-repo
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,14 +37,28 @@ jobs:
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+        run: |
+          bazel \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc \
+            test \
+            --disk_cache=${HOME}/.cache/bazel \
+            --repository_cache=${HOME}/.cache/bazel-repo \
+            //...
       - name: bazel build //example:image && docker load
         if: ${{ matrix.os != 'macos-latest' }}
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: |
-          bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc build //example/js:image //example/py:image
+          bazel \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc \
+            build \
+            --disk_cache=${HOME}/.cache/bazel \
+            --repository_cache=${HOME}/.cache/bazel-repo \
+            //example/js:image \
+            //example/py:image
           docker load -i bazel-bin/example/js/image.tar
           docker run --rm image:latest
           docker load -i bazel-bin/example/py/image.tar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,14 @@ jobs:
         env:
           # Bazelisk will download bazel to here
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+        run: |
+          bazel \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc \
+            test \
+            --disk_cache=${HOME}/.cache/bazel \
+            --repository_cache=${HOME}/.cache/bazel-repo \
+            //...
       - name: Rename release artifact with version
         run: cp $(ls bazel-out/*/bin/*.tar.gz | tail -1) "rules_container-$(git describe --tags | sed 's/^v//').tar.gz"
       # TODO: move this into bazel to produce the file with expand_template rule when it has stamping


### PR DESCRIPTION
@thesayyn Some more fixes to ci build cacheing. See the rules-template changes here: https://github.com/bazel-contrib/rules-template/pull/4

Apparently bazelrc doesn't recognize environment variables.