### PR TITLE
build: move ci cache flags to bazelrc

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -3,6 +3,9 @@
 
 # Debug where options came from
 build --announce_rc
+# This directory is configured in GitHub actions to be persisted between runs.
+build --disk_cache=~/.cache/bazel
+build --repository_cache=~/.cache/bazel-repo
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,28 +35,14 @@ jobs:
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: |
-          bazel \
-            --bazelrc=.github/workflows/ci.bazelrc \
-            --bazelrc=.bazelrc \
-            test \
-            --disk_cache=${HOME}/.cache/bazel \
-            --repository_cache=${HOME}/.cache/bazel-repo \
-            //...
+        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
       - name: bazel build //example:image && docker load
         if: ${{ matrix.os != 'macos-latest' }}
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: |
-          bazel \
-            --bazelrc=.github/workflows/ci.bazelrc \
-            --bazelrc=.bazelrc \
-            build \
-            --disk_cache=${HOME}/.cache/bazel \
-            --repository_cache=${HOME}/.cache/bazel-repo \
-            //example/js:image \
-            //example/py:image
+          bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc build //example/js:image //example/py:image
           docker load -i bazel-bin/example/js/image.tar
           docker run --rm image:latest
           docker load -i bazel-bin/example/py/image.tar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,7 @@ jobs:
         env:
           # Bazelisk will download bazel to here
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: |
-          bazel \
-            --bazelrc=.github/workflows/ci.bazelrc \
-            --bazelrc=.bazelrc \
-            test \
-            --disk_cache=${HOME}/.cache/bazel \
-            --repository_cache=${HOME}/.cache/bazel-repo \
-            //...
+        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
       - name: Rename release artifact with version
         run: cp $(ls bazel-out/*/bin/*.tar.gz | tail -1) "rules_container-$(git describe --tags | sed 's/^v//').tar.gz"
       # TODO: move this into bazel to produce the file with expand_template rule when it has stamping


### PR DESCRIPTION
Sorry to keep changing this, but we've settled on putting the cache flags in bazelrc in rules-template since we realized that it supports `~` paths. Feel free to keep or close as this doesn't change anything functionally.